### PR TITLE
Make PDF test compatible both with 54 and 55

### DIFF
--- a/e2e/test/compatibility.cy.spec.js
+++ b/e2e/test/compatibility.cy.spec.js
@@ -77,7 +77,7 @@ const TIMEOUT_MS = 20000;
       expect(cy.findByTestId("embed-frame", {timeout: TIMEOUT_MS}).should("exist"));
       cy.findByTestId("embed-frame", {timeout: TIMEOUT_MS}).within(() => {
         cy.findByTestId("fixed-width-dashboard-header").within(() => {
-          cy.findByText('Export tab as PDF').click();
+          cy.get('button svg.Icon-download, button svg.Icon-document').first().click();
         });
 
         cy.readFile('cypress/downloads/E-commerce Insights.pdf', {timeout: TIMEOUT_MS}).should('exist');


### PR DESCRIPTION
Make PDF test compatible both with 54 and 55

This is a temporal fix, for the `main` branch here we actually should run e2e against the `master` SDK, or disable e2e for the `main` branch at all