### PR TITLE
Increase e2e tests timeout

### DIFF
--- a/e2e/test/compatibility.cy.spec.js
+++ b/e2e/test/compatibility.cy.spec.js
@@ -1,4 +1,4 @@
-const TIMEOUT_MS = 20000;
+const TIMEOUT_MS = 40000;
 
 [
   {


### PR DESCRIPTION
Needed for upcoming tests of the Next.js dev mode against esbuild bundle
It is compiling during page loading, so we have to increase timeout.