### PR TITLE
Additional adjustments for metabase@55

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       MB_JWT_SHARED_SECRET: "${METABASE_JWT_SHARED_SECRET}"
       MB_SETUP_TOKEN: "${PREMIUM_EMBEDDING_TOKEN}"
       MB_PREMIUM_EMBEDDING_TOKEN: "${PREMIUM_EMBEDDING_TOKEN}"
+      MB_JWT_IDENTITY_PROVIDER_URI: "http://localhost:${AUTH_PROVIDER_PORT}/sso/metabase"
     healthcheck:
       test: curl --fail -X GET -I "http://localhost:${MB_PORT}/api/health" || exit 1
       interval: 15s

--- a/next-sample-app-router/package-lock.json
+++ b/next-sample-app-router/package-lock.json
@@ -8,7 +8,7 @@
       "name": "next-sample-app-router",
       "version": "0.1.0",
       "dependencies": {
-        "@metabase/embedding-sdk-react": "^0.55.2-nightly",
+        "@metabase/embedding-sdk-react": "^0.55.2",
         "dotenv-cli": "^8.0.0",
         "jsonwebtoken": "^9.0.2",
         "next": "14.2.18",
@@ -1078,9 +1078,9 @@
       "license": "MIT"
     },
     "node_modules/@metabase/embedding-sdk-react": {
-      "version": "0.55.2-nightly",
-      "resolved": "https://registry.npmjs.org/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.55.2-nightly.tgz",
-      "integrity": "sha512-CIw0eSzhNw2jxUeAaoL9Xlk+fGZgAIlDVOOM4+aBOAFLmJ2s/PMnsDh8seJlDzSYTzwUkQciAOXcFPJRbrjWJA==",
+      "version": "0.55.2",
+      "resolved": "https://registry.npmjs.org/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.55.2.tgz",
+      "integrity": "sha512-PQGqEBOc5yefmNQ1JNj8PggoE0UmOulf/tE4np9PkJJsZh7FIrtaY96HfWD14G1hdzbJQfUuhZrLuWcRC6fRDQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",

--- a/next-sample-app-router/package.json
+++ b/next-sample-app-router/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@metabase/embedding-sdk-react": "^0.55.2-nightly",
+    "@metabase/embedding-sdk-react": "^0.55.2",
     "dotenv-cli": "^8.0.0",
     "jsonwebtoken": "^9.0.2",
     "next": "14.2.18",

--- a/next-sample-pages-router/package-lock.json
+++ b/next-sample-pages-router/package-lock.json
@@ -8,7 +8,7 @@
       "name": "next-sample-pages-router",
       "version": "0.1.0",
       "dependencies": {
-        "@metabase/embedding-sdk-react": "^0.55.2-nightly",
+        "@metabase/embedding-sdk-react": "^0.55.2",
         "dotenv-cli": "^8.0.0",
         "jsonwebtoken": "^9.0.2",
         "next": "14.2.18",
@@ -1078,9 +1078,9 @@
       "license": "MIT"
     },
     "node_modules/@metabase/embedding-sdk-react": {
-      "version": "0.55.2-nightly",
-      "resolved": "https://registry.npmjs.org/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.55.2-nightly.tgz",
-      "integrity": "sha512-CIw0eSzhNw2jxUeAaoL9Xlk+fGZgAIlDVOOM4+aBOAFLmJ2s/PMnsDh8seJlDzSYTzwUkQciAOXcFPJRbrjWJA==",
+      "version": "0.55.2",
+      "resolved": "https://registry.npmjs.org/@metabase/embedding-sdk-react/-/embedding-sdk-react-0.55.2.tgz",
+      "integrity": "sha512-PQGqEBOc5yefmNQ1JNj8PggoE0UmOulf/tE4np9PkJJsZh7FIrtaY96HfWD14G1hdzbJQfUuhZrLuWcRC6fRDQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.3",

--- a/next-sample-pages-router/package.json
+++ b/next-sample-pages-router/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@metabase/embedding-sdk-react": "^0.55.2-nightly",
+    "@metabase/embedding-sdk-react": "^0.55.2",
     "dotenv-cli": "^8.0.0",
     "jsonwebtoken": "^9.0.2",
     "next": "14.2.18",


### PR DESCRIPTION
- PR updates SDK to 0.55.2
- PR sets `MB_JWT_IDENTITY_PROVIDER_URI` that is not required