### PR TITLE
Change test IDs to match SdkDashboard

### DIFF
--- a/e2e/test/compatibility.cy.spec.js
+++ b/e2e/test/compatibility.cy.spec.js
@@ -41,12 +41,12 @@ const TIMEOUT_MS = 40000;
       });
 
       expect(cy.findByTestId("embed-frame", {timeout: TIMEOUT_MS}).should("exist"));
-      cy.findByTestId("embed-frame", {timeout: TIMEOUT_MS}).within(() => {
-        cy.findByTestId("embed-frame-header").should("exist");
+      cy.findByTestId("dashboard", {timeout: TIMEOUT_MS}).within(() => {
+        cy.findByTestId("dashboard-name-heading").should("exist");
 
         cy.findByText("E-commerce Insights").should("exist");
 
-        cy.findByTestId("fixed-width-filters").should("exist");
+        cy.findByTestId("dashboard-parameters-widget-container").should("exist");
 
         cy.findByTestId("dashboard-grid").should("exist");
       });
@@ -58,12 +58,12 @@ const TIMEOUT_MS = 40000;
       });
 
       expect(cy.findByTestId("embed-frame", {timeout: TIMEOUT_MS}).should("exist"));
-      cy.findByTestId("embed-frame", {timeout: TIMEOUT_MS}).within(() => {
-        cy.findByTestId("embed-frame-header").should("exist");
+      cy.findByTestId("dashboard", {timeout: TIMEOUT_MS}).within(() => {
+        cy.findByTestId("dashboard-name-heading").should("exist");
 
         cy.findByText("E-commerce Insights").should("exist");
 
-        cy.findByTestId("fixed-width-filters").should("exist");
+        cy.findByTestId("dashboard-parameters-widget-container").should("exist");
 
         cy.findByTestId("dashboard-grid").should("exist");
       });


### PR DESCRIPTION
This new addition is to fix the failures [here](https://github.com/metabase/metabase/actions/runs/16288552070/job/45993570792?pr=60835) for [backported "Convert DashboardParameters to dashboard context"](https://github.com/metabase/metabase/pull/60835).

This PR contains #60101 which adds the SdkDashboard but also moves the dashboards away from using `embed-frame`